### PR TITLE
feat: key prefix encoding

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 pub mod builder;
 pub mod iterator;
 pub mod metadata;
@@ -52,6 +54,12 @@ impl Block {
             end_of_data_offset,
         }
     }
+
+    pub fn get_first_key(&self) -> Bytes {
+        let key_len = u16::from_be_bytes([self.data[0], self.data[1]]);
+        let key = self.data[2..2+key_len as usize].to_vec();
+        Bytes::from(key)
+    }
 }
 
 #[cfg(test)]
@@ -81,5 +89,7 @@ mod tests {
 
         let decoded_block = Block::decode(actual);
         assert_eq!(block, decoded_block);
+
+        assert_eq!(block.get_first_key(), "k1".as_bytes());
     }
 }

--- a/src/block/iterator.rs
+++ b/src/block/iterator.rs
@@ -13,24 +13,29 @@ pub struct BlockIterator {
     block: Arc<Block>,
     current_index: usize,
     current_kv: Option<KeyValuePair>,
+    first_key: Bytes,
 }
 
 impl BlockIterator {
     pub fn create_and_seek_to_first(block: Arc<Block>) -> Self {
+        let first_key = block.get_first_key();
         let mut res = Self {
             block,
             current_index: 0,
             current_kv: None,
+            first_key,
         };
         res.current_kv = res.parse_current_kv();
         res
     }
 
     pub fn create_and_seek_to_key(block: Arc<Block>, key: TimestampedKey) -> Self {
+        let first_key = block.get_first_key();
         let mut res = Self {
             block,
             current_index: 0,
             current_kv: None,
+            first_key,
         };
         res.seek_to_key(key);
         res
@@ -72,26 +77,46 @@ impl BlockIterator {
 
         let current_offset = self.block.offsets[self.current_index];
         // parse key
-        let key_contents_offset = current_offset + 2;
-        let key_size = u16::from_be_bytes(
-            self.block.data[current_offset.into()..key_contents_offset.into()]
-                .try_into()
-                .expect("chunk of size 2"),
-        );
-        let key_slice =
-            &self.block.data[key_contents_offset.into()..(key_contents_offset + key_size).into()];
+        let key_contents_offset: usize;
+        let key_vec: Vec<u8>;
+        let value_contents_offset: usize;
+        if self.current_index == 0 {
+            key_contents_offset = current_offset as usize + 2;
+            let key_size = u16::from_be_bytes(
+                self.block.data[current_offset.into()..key_contents_offset]
+                    .try_into()
+                    .expect("chunk of size 2"),
+            ) as usize;
+            key_vec =
+                self.block.data[key_contents_offset.into()..(key_contents_offset + key_size).into()].to_vec();
+            value_contents_offset = key_contents_offset + key_size + 2;
+        } else {
+            key_contents_offset = current_offset as usize + 4;
+            let key_overlap_len = u16::from_be_bytes(
+                self.block.data[current_offset as usize..current_offset as usize + 2]
+                    .try_into()
+                    .expect("chunk of size 2"),
+            ) as usize;
+            let key_overlap = &self.first_key[..key_overlap_len];
+            let rest_key_len = u16::from_be_bytes(
+                self.block.data[current_offset as usize + 2..key_contents_offset as usize]
+                    .try_into()
+                    .expect("chunk of size 2"),
+            ) as usize;
+            let rest_key = &self.block.data[key_contents_offset..key_contents_offset + rest_key_len];
+            key_vec = [key_overlap, rest_key].concat().to_vec();
+            value_contents_offset = key_contents_offset + rest_key_len + 2;
+        }
         // parse value
-        let value_contents_offset = key_contents_offset + key_size + 2;
         let value_size = u16::from_be_bytes(
             self.block.data[(value_contents_offset - 2).into()..value_contents_offset.into()]
                 .try_into()
                 .expect("chunk of size 2"),
-        );
+        ) as usize;
         let value_slice = &self.block.data
-            [value_contents_offset.into()..(value_contents_offset + value_size).into()];
-
+            [value_contents_offset..value_contents_offset + value_size];
         Some(KeyValuePair {
-            key: TimestampedKey::new(Bytes::copy_from_slice(key_slice)),
+            key: TimestampedKey::new(Bytes::from(key_vec)),
             value: Bytes::copy_from_slice(value_slice),
         })
     }
@@ -150,6 +175,7 @@ mod tests {
         let block = Arc::new(block_builder.build());
 
         let mut block_iterator = BlockIterator::create_and_seek_to_first(block);
+        assert_eq!(block_iterator.first_key, "k1".as_bytes());
         assert!(block_iterator.peek().is_some());
         assert_eq!(
             block_iterator
@@ -167,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_seek_to_key() {
-        let mut block_builder = BlockBuilder::new(32);
+        let mut block_builder = BlockBuilder::new(50);
         assert!(block_builder
             .add(KeyValuePair {
                 key: TimestampedKey::new("k1".as_bytes().into()),

--- a/src/table/file.rs
+++ b/src/table/file.rs
@@ -104,10 +104,10 @@ mod tests {
                 value: "v2".as_bytes().into()
             })
             .is_ok());
-        // 2 * 8 bytes per kv pair
+        // 8 bytes for first kv pair; 9 bytes for subsequent kv pairs
         // 2 * 2 bytes per offset
         // 2 bytes for end of data offset
-        let expected_block_size = 2 * 8 + 2 * 2 + 2;
+        let expected_block_size = 8 + 9 + 2 * 2 + 2;
         assert_eq!(block_builder.get_block_size(), expected_block_size);
         let block = block_builder.build();
         let data = block.encode();
@@ -130,7 +130,7 @@ mod tests {
         let mut file = sst.file;
         let bloom_filter_offset = file.get_bloom_filter_offset().unwrap();
         let meta_block_offset = file.get_meta_block_offset(bloom_filter_offset).unwrap();
-        assert_eq!(meta_block_offset, 34);
+        assert_eq!(meta_block_offset, 35);
 
         let meta_blocks = file.load_meta_blocks(meta_block_offset, bloom_filter_offset).unwrap();
         let expected_meta_1 = BlockMetadata::new(
@@ -139,7 +139,7 @@ mod tests {
             TimestampedKey::new("k2".as_bytes().into()),
         );
         let expected_meta_2 = BlockMetadata::new(
-            22,
+            23,
             TimestampedKey::new("k3".as_bytes().into()),
             TimestampedKey::new("k3".as_bytes().into()),
         );


### PR DESCRIPTION
implement key prefix encoding: for all keys after the first key, encode the key as
```
key_overlap (u16) | rest_key_len (u16) | rest_key
```
rather than
```
key_len (u16) | key
```
where `key_overlap` is the number of bytes in common with the first key, and `rest_key` is the remainder of the key after the common prefix.